### PR TITLE
Example send message

### DIFF
--- a/examples/BleDuckApp/BleDuckapp.ino
+++ b/examples/BleDuckApp/BleDuckapp.ino
@@ -1,0 +1,35 @@
+#include "ClusterDuck.h"
+#include "BluetoothSerial.h"
+#include <BLEDevice.h>
+#include <BLEUtils.h>
+#include <BLEServer.h>
+
+ClusterDuck duck;
+
+#if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
+#error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
+#endif
+
+BluetoothSerial SerialBT;
+
+void setup() {
+  duck.begin();
+  duck.setDeviceId("ble");
+  duck.setupLoRa();
+  duck.setupDisplay("BLE");
+
+  SerialBT.begin("DuckLink1"); //Bluetooth device name
+  Serial.println("The device started, now you can pair it with bluetooth!");
+
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+
+  if (SerialBT.available()) {
+    String text = SerialBT.readString();
+    Serial.println(text);
+    duck.sendPayloadStandard(text, "app");
+    delay(10);
+  }
+}

--- a/examples/SendMessageExample/.gitignore
+++ b/examples/SendMessageExample/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/SendMessageExample/SendMessageExample.ino
+++ b/examples/SendMessageExample/SendMessageExample.ino
@@ -1,0 +1,37 @@
+#include "timer.h"
+#include <ClusterDuck.h>
+
+/**
+ * This example creates a mama duck that sends a counter message
+ * every 30 seconds towards a papa duck.
+ * For sensor based examples see: ClusterDuck-Protocol/examples/SensorExamples
+ */
+
+ClusterDuck duck;
+
+auto timer = timer_create_default(); // create a timer with default settings
+const int INTERVAL_MS = 30000;
+char message[32]; 
+int counter = 1;
+
+void setup() {
+  // put your setup code here, to run once:
+  duck.begin();
+  duck.setDeviceId("MAMA-DUCK");
+  duck.setupMamaDuck();
+  timer.every(INTERVAL_MS, runSensor);
+}
+
+void loop() {
+  timer.tick();
+  
+  // put your main code here, to run repeatedly:
+  duck.runMamaDuck();
+}
+
+bool runSensor(void *) {
+  sprintf(message, "Mama duck counter %d", counter++); 
+  duck.sendPayloadStandard(message, "message-test", "MAMA-DUCK");
+  
+  return true;
+}

--- a/examples/SendMessageExample/platformio.ini
+++ b/examples/SendMessageExample/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:heltec_wifi_lora_32_V2]
+platform = espressif32
+board = heltec_wifi_lora_32_V2
+framework = arduino
+monitor_speed = 115200
+monitor_filters = time
+
+lib_deps = 
+     ClusterDuck Protocol
+
+; uncommend for OTA update
+; upload_port = duck.local


### PR DESCRIPTION
While setting up my "mini" cluster, I needed to see an example that sent a message without having to find a sensor to connect to the mama duck.

This example uses the same template as other examples, but it simply increments a counter each time a message is sent (every 30 seconds) and the message contains the count.
Using that example, from a mama duck to a papa duck I could verify the entire message flow, all the way to the cloud dash-board.